### PR TITLE
Improve detection of restricted tokens

### DIFF
--- a/NtApiDotNet/NtToken.cs
+++ b/NtApiDotNet/NtToken.cs
@@ -1987,7 +1987,7 @@ namespace NtApiDotNet
         {
             get
             {
-                return RestrictedSidsCount > 0;
+                return Query<int>(TokenInformationClass.TokenIsRestricted) != 0;
             }
         }
 


### PR DESCRIPTION
Although restricted tokens almost always contain restricting SIDs that's not absolutely necessary. We can create a write-restricted token with the following code:

    NtFilterToken(
        hToken,
        WRITE_RESTRICTED,
        NULL, // SIDs to disable
        NULL, // privileges to delete
        NULL, // restricted SIDs
        hNewToken, 
    );

It results in a token that effectively has no write access since there are no items in the list to provide it. Hence, checking whether a token is a restricted one by examining the list of these SIDs might not work correctly. Querying the information class `TokenIsRestricted` is quite what we need since it actually checks whether its `TokenFlags` field contains `TOKEN_IS_RESTRICTED | TOKEN_WRITE_RESTRICTED`.