### PR TITLE
IPeb: Added GetBeingDebugged()

### DIFF
--- a/NtApiDotNet/NtProcessNative.cs
+++ b/NtApiDotNet/NtProcessNative.cs
@@ -780,6 +780,7 @@ namespace NtApiDotNet
 
     public interface IPeb
     {
+        bool GetBeingDebugged();
         PebFlags GetPebFlags();
         IntPtr GetImageBaseAddress();
         IntPtr GetProcessHeap();
@@ -805,6 +806,11 @@ namespace NtApiDotNet
         public IntPtr ProcessParameters; // PRTL_USER_PROCESS_PARAMETERS
         public IntPtr SubSystemData;
         public IntPtr ProcessHeap;
+
+        public bool GetBeingDebugged()
+        {
+            return BeingDebugged;
+        }
 
         IntPtr IPeb.GetProcessParameters()
         {
@@ -846,6 +852,11 @@ namespace NtApiDotNet
         public int ProcessParameters; // PRTL_USER_PROCESS_PARAMETERS
         public int SubSystemData;
         public int ProcessHeap;
+
+        public bool GetBeingDebugged()
+        {
+            return BeingDebugged;
+        }
 
         IntPtr IPeb.GetImageBaseAddress()
         {


### PR DESCRIPTION
I need to access the BeingDebugged field of the partial PEB as a mean to more reliably detect an external process being debugged (CheckRemoteDebuggerPresent checks also for a debug port being present[1]), so I just added it to the `IPeb` interface. The change is trivial. 

Any reason the methos in `IPeb` are not actually properties? Being just O(1) accessors it doesn't fit well with C# if they are methods.

[1] https://xorl.wordpress.com/2017/12/09/the-checkremotedebuggerpresent-anti-debugging-technique/