### PR TITLE
Fix scoping issue for CredentialHandle object

### DIFF
--- a/NtApiDotNet/Win32/Rpc/Transport/RpcTransportSecurity.cs
+++ b/NtApiDotNet/Win32/Rpc/Transport/RpcTransportSecurity.cs
@@ -203,12 +203,9 @@ namespace NtApiDotNet.Win32.Rpc.Transport
                     throw new ArgumentException($"Unsupported authentication level {AuthenticationLevel}");
             }
 
-            using (var creds = CredentialHandle.Create(GetAuthPackageName(),
-                    SecPkgCredFlags.Outbound, Credentials))
-            {
-                return new ClientAuthenticationContext(creds, GetContextRequestFlags(),
-                    ServicePrincipalName, SecDataRep.Native);
-            }
+            return new ClientAuthenticationContext(CredentialHandle.Create(GetAuthPackageName(),
+                SecPkgCredFlags.Outbound, Credentials), GetContextRequestFlags(),
+                ServicePrincipalName, SecDataRep.Native);
         }
         #endregion
     }


### PR DESCRIPTION
When performing anything above `RpcAuthenticationLevel.None` and `NTLM` auth (w/ `ncacn_np` although I doubt it's relevant), the `CredentialHandle` object maintained by `ClientAuthenticationContext` can go out of scope and dispose before the second call to `InitializeSecurityContext` is made. This results in `SEC_E_INVALID_HANDLE` being thrown.

An example stack trace from the failure:

```
at NtApiDotNet.NtObjectUtils.ToNtException(NtStatus status, Boolean throw_on_error)
at NtApiDotNet.Win32.Security.Native.SecurityNativeMethods.CheckResult(SecStatusCode result, Boolean throw_on_error)
at NtApiDotNet.Win32.Security.Authentication.SecurityContextUtils.InitializeSecurityContext(CredentialHandle credential, SecHandle context, String target_name, InitializeContextReqFlags req_attributes, SecDataRep data_rep, IList`1 input, SecHandle new_context, IList`1 output, InitializeContextRetFlags& ret_attributes, LargeInteger expiry, Boolean throw_on_error)
at NtApiDotNet.Win32.Security.Authentication.ClientAuthenticationContext.CallInitialize(List`1 input_buffers, List`1 output_buffers, Boolean throw_on_error)
at NtApiDotNet.Win32.Security.Authentication.ClientAuthenticationContext.Continue(IEnumerable`1 input_buffers, IEnumerable`1 additional_output, Boolean throw_on_error)
at NtApiDotNet.Win32.Security.Authentication.ClientAuthenticationContext.Continue(IEnumerable`1 input_buffers, IEnumerable`1 additional_output)
at NtApiDotNet.Win32.Security.Authentication.ClientAuthenticationContext.Continue(AuthenticationToken token, IEnumerable`1 additional_input, IEnumerable`1 additional_output)
at NtApiDotNet.Win32.Security.Authentication.ClientAuthenticationContext.Continue(AuthenticationToken token, IEnumerable`1 additional_input)
at NtApiDotNet.Win32.Security.Authentication.ClientAuthenticationContext.Continue(AuthenticationToken token)
at NtApiDotNet.Win32.Rpc.Transport.RpcConnectedClientTransport.BindAuth(Boolean alter_context, RpcTransportSecurityContext security_context)
at NtApiDotNet.Win32.Rpc.Transport.RpcConnectedClientTransport.Bind(Guid interface_id, Version interface_version, Guid transfer_syntax_id, Version transfer_syntax_version)
at NtApiDotNet.Win32.Rpc.RpcClientBase.Connect(RpcEndpoint endpoint, RpcTransportSecurity transport_security)
at NtApiDotNet.Win32.Rpc.RpcClientBase.Connect(String protocol_seq, String endpoint, String network_address, RpcTransportSecurity transport_security)
```

There was a pre-existing `using` wrap which makes me believe the scoping of this `CredentialHandle` has been considered before. I just let the `ClientAuthenticationContext` own the scope and things seem to work fine now. You might have a better solution James.