### PR TITLE
Added functions to create custom desktops with CreateDesktop and CreateDesktopEx

### DIFF
--- a/NtApiDotNet/Win32/Win32NativeMethods.cs
+++ b/NtApiDotNet/Win32/Win32NativeMethods.cs
@@ -1336,6 +1336,27 @@ namespace NtApiDotNet.Win32
             SECURITY_ATTRIBUTES lpsa
         );
 
+        [DllImport("user32.dll", EntryPoint = "CreateDesktop", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern SafeKernelObjectHandle CreateDesktop(
+            string desktopName,
+            IntPtr device,     // must be null.
+            IntPtr deviceMode, // must be null,
+            int flags,         // use 0
+            AccessMask dwDesiredAccess,
+            SECURITY_ATTRIBUTES attributes);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern SafeKernelObjectHandle CreateDesktopEx(
+            string desktopName,
+            IntPtr device,     // must be null.
+            IntPtr deviceMode, // must be null,
+            int flags,         // use 0
+            AccessMask dwDesiredAccess,
+            SECURITY_ATTRIBUTES attributes,
+            ulong heapSize,
+            IntPtr pVoid);
+
+
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern SafeKernelObjectHandle CreateRemoteThreadEx(
             SafeKernelObjectHandle hProcess,

--- a/NtApiDotNet/Win32/Win32Utils.cs
+++ b/NtApiDotNet/Win32/Win32Utils.cs
@@ -526,6 +526,35 @@ namespace NtApiDotNet.Win32
         }
 
         /// <summary>
+        /// This creates a Desktop using the User32 API.
+        /// </summary>
+        /// <param name="name">The name of the Desktop.</param>
+        /// <returns>The Desktop.</returns>
+        public static NtDesktop CreateDesktop(string name)
+        {
+            var handle = Win32NativeMethods.CreateDesktop(name, IntPtr.Zero, IntPtr.Zero, 0, WindowStationAccessRights.MaximumAllowed, null);
+            if (handle.IsInvalid)
+                throw new SafeWin32Exception();
+            return new NtDesktop(handle);
+        }
+
+        /// <summary>
+        /// This creates a Desktop using the User32 API.
+        /// </summary>
+        /// <param name="name">The name of the Desktop.</param>
+        /// <param name="heapSize">The size of the desktop heap, in kilobytes.</param>
+        /// <returns>The Desktop.</returns>
+        public static NtDesktop CreateDesktop(string name, ulong heapSize)
+        {
+            var handle = Win32NativeMethods.CreateDesktopEx(name, IntPtr.Zero, IntPtr.Zero, 0, WindowStationAccessRights.MaximumAllowed, null, heapSize,
+                                                            IntPtr.Zero);
+            if (handle.IsInvalid)
+                throw new SafeWin32Exception();
+            return new NtDesktop(handle);
+        }
+
+
+        /// <summary>
         /// Create a remote thread.
         /// </summary>
         /// <param name="process">The process to create the thread in.</param>


### PR DESCRIPTION
Win32Utils has a CreateWindowStation function, but did not have any helper methods to create custom desktops via CreateDesktop and CreateDesktopEx.