### PR TITLE
Fixed memory corruption bug when obtaining 64bit thread context

### DIFF
--- a/NtApiDotNet/NtThreadNative.cs
+++ b/NtApiDotNet/NtThreadNative.cs
@@ -470,6 +470,8 @@ namespace NtApiDotNet
         public M128A Xmm13;
         public M128A Xmm14;
         public M128A Xmm15;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 96)]
+        public byte[] Padding;
 
         //
         // Vector registers.


### PR DESCRIPTION
The floating point register state is held within a union inside the native struct within winnt.h.  This union is 512 bytes in size.  This commit adds an additional 96 bytes of padding after the floating point state to ensure that the complete structure is the correct size of 1232 bytes and to ensure the vector registers and additional amd64 debug control registers are now populated correctly.