### PR TITLE
made some custom transport implementation possible

### DIFF
--- a/NtApiDotNet/Win32/Rpc/RpcClientBase.cs
+++ b/NtApiDotNet/Win32/Rpc/RpcClientBase.cs
@@ -27,7 +27,7 @@ namespace NtApiDotNet.Win32.Rpc
     public abstract class RpcClientBase : IDisposable
     {
         #region Private Members
-        private IRpcClientTransport _transport;
+        protected IRpcClientTransport _transport;
 
         private RpcEndpoint LookupEndpoint(string protocol_seq, string network_address)
         {

--- a/NtApiDotNet/Win32/Rpc/Transport/RpcConnectedClientTransport.cs
+++ b/NtApiDotNet/Win32/Rpc/Transport/RpcConnectedClientTransport.cs
@@ -29,6 +29,8 @@ namespace NtApiDotNet.Win32.Rpc.Transport
     public abstract class RpcConnectedClientTransport : IRpcClientTransport
     {
         #region Protected Members
+        protected ushort _max_recv_fragment;
+        protected ushort _max_send_fragment;
 
         /// <summary>
         /// Constructor.
@@ -78,8 +80,6 @@ namespace NtApiDotNet.Win32.Rpc.Transport
         private readonly Dictionary<int, RpcTransportSecurityContext> _security_context;
         private RpcTransportSecurityContext _current_security_context;
         private int _current_context_id;
-        private ushort _max_recv_fragment;
-        private ushort _max_send_fragment;
         private int _assoc_group_id;
         private int _recv_sequence_no;
         private int _send_sequence_no;
@@ -519,7 +519,7 @@ namespace NtApiDotNet.Win32.Rpc.Transport
         /// <param name="interface_version">The interface version to bind to.</param>
         /// <param name="transfer_syntax_id">The transfer syntax to use.</param>
         /// <param name="transfer_syntax_version">The transfer syntax version to use.</param>
-        public void Bind(Guid interface_id, Version interface_version, Guid transfer_syntax_id, Version transfer_syntax_version)
+        public virtual void Bind(Guid interface_id, Version interface_version, Guid transfer_syntax_id, Version transfer_syntax_version)
         {
             if (transfer_syntax_id != Ndr.NdrNativeUtils.DCE_TransferSyntax || transfer_syntax_version != new Version(2, 0))
             {


### PR DESCRIPTION
Hey,

im using your library at work and i needed to make it linux compatible. I made some very minor changes that allowed me to make my own `RpcConnectedClientTransport` implementation. The changes made it possible to use the [SMBLibrary](https://github.com/TalAloni/SMBLibrary) as my transport method instead of the pinvoke/windows-dependant one. If you don't mind, it would be nice to have those changes in the main repo so:
1. others may benefit from making their own transport implementation
2. i don't have to maintain my own fork :p

Have a nice day :)
Also thanks so much for creating this awesome project!