### PR TITLE
Avoid `-` characters in generated union names

### DIFF
--- a/NtApiDotNet/Ndr/NdrUnionTypes.cs
+++ b/NtApiDotNet/Ndr/NdrUnionTypes.cs
@@ -37,7 +37,7 @@ namespace NtApiDotNet.Ndr
         {
             if (case_value < 0)
             {
-                return $"minus_{case_value}";
+                return $"minus_{Math.Abs(case_value)}";
             }
             return case_value.ToString();
         }


### PR DESCRIPTION
Should be a pretty simple one, but when dealing with negative selector values for a union type, the generated name might end up like `Arm_minus_-1` which fails compilation. Credit to @moohax for the find.

Looks like negative values were already considered, so I just added `Math.Abs` to shore things up.

Failing example:
```
> $server = Get-RpcServer C:\windows\system32\wbiosrvc.dll
> $server[0] | Get-RpcClient
```