### PR TITLE
Fix for ParseEnvironmentBlock - switching to ordinal search for end_index

### DIFF
--- a/NtApiDotNet/NtProcessEnvironmentVariable.cs
+++ b/NtApiDotNet/NtProcessEnvironmentVariable.cs
@@ -54,7 +54,7 @@ namespace NtApiDotNet
         internal static IEnumerable<NtProcessEnvironmentVariable> ParseEnvironmentBlock(byte[] environment)
         {
             string env_str = Encoding.Unicode.GetString(environment);
-            int end_index = env_str.IndexOf("\0\0");
+            int end_index = env_str.IndexOf("\0\0", StringComparison.Ordinal);
             if (end_index >= 0)
             {
                 env_str = env_str.Substring(0, end_index);


### PR DESCRIPTION
The `IndexOf(\0\0)` call in the `ParseEnvironmentBlock` function does not work as expected starting from .NET 5, because of [changes in the globalization API](https://github.com/dotnet/runtime/issues/80298#issuecomment-1373868926). This PR fixes the problem by forcing the ordinal search for the `\0\0` token.