### PR TITLE
Fix parsing of NDR Union arm types

### DIFF
--- a/NtApiDotNet/Ndr/NdrUnionTypes.cs
+++ b/NtApiDotNet/Ndr/NdrUnionTypes.cs
@@ -53,7 +53,7 @@ namespace NtApiDotNet.Ndr
         internal static NdrBaseTypeReference ReadArmType(NdrParseContext context, BinaryReader reader)
         {
             ushort type = reader.ReadUInt16();
-            if ((type & 0x8F00) == 0x8000)
+            if ((type & 0xFF00) == 0x8000)
             {
                 return new NdrSimpleTypeReference((NdrFormatCharacter)(type & 0xFF));
             }


### PR DESCRIPTION
When parsing NDR Union arm types, the `offset_to_arm_description` is incorrectly parsed for certain values. According to the [documentation](https://learn.microsoft.com/en-us/windows/win32/rpc/unions-tfs) possible values for the `offset_to_arm_description` are:

```
    0 - empty default
    FFFF - no default
    80xx - simple type
    other - relative offset
```

In the current implementation, the third condition is checked by the following lines of code:

```cs
ushort type = reader.ReadUInt16();
if ((type & 0x8F00) == 0x8000)
{
    return new NdrSimpleTypeReference((NdrFormatCharacter)(type & 0xFF));
}
```

Unfortunately, this branch of the if statement is also entered for a relative offset like `0xf0ea`. To fix the issue, it should be sufficient to change `type & 0x8F00` to `type & 0xFF00`. This makes sure that the upper byte is really `FC_MAGIC_UNION_BYTE` before treating the arm as simple type.
