### PR TITLE
bug fix in <NtFile>.Read(<length>), null is not 0 in RunFileCallSync

### DIFF
--- a/NtApiDotNet/NtFile.cs
+++ b/NtApiDotNet/NtFile.cs
@@ -2379,6 +2379,8 @@ namespace NtApiDotNet
         /// <returns>The length of bytes read into the buffer.</returns>
         public NtResult<int> Read(SafeBuffer buffer, long? position, bool throw_on_error)
         {
+            //null is not the same as zero within RunFileCallSync.  I did not investigate further than this fix.
+            position = position ?? 0;
             return RunFileCallSync(r => NtSystemCalls.NtReadFile(Handle, r.EventHandle, IntPtr.Zero,
                     IntPtr.Zero, r.IoStatusBuffer, buffer, 
                     buffer.GetLength(), position.ToLargeInteger(), IntPtr.Zero), throw_on_error)


### PR DESCRIPTION
This is the error I was getting
`
$file = Get-NtFile <some_path> -win32path
$file.read(5)
Exception calling "Read" with "1" argument(s): "(0xC000000D) - An invalid parameter was passed to a service or
function."
At line:1 char:187
+ ... t-NtFile C:\Users\ben\Documents\desktop.ini -Win32Path; $file.read(3)
+                                                             ~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : NtException
`

I'm not a c# person and I didn't dive into if there are underlying problems beyond where I made my fix.  While I would have expected null and 0 to be the same, they don't appear to be so I just made the lowest level fix that made sense to me.  

let me know if you have any questions.